### PR TITLE
Add basic macOS compilation functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
+.idea/*
+CMakeFiles/*
 build/
+*.dylib
 *.o
+*.so
 moc_*.cpp
 ui_*.h
 *~
@@ -7,7 +11,10 @@ vb-agent
 res/.directory
 .\#*
 \#*#
+CMakeCache.txt
+CMakeLists.txt
 Makefile
 Trolltech.conf
+cmake_install.cmake
 obj-i686-linux-gnu
 syscall-names.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,26 @@
 cmake_minimum_required (VERSION 2.4)
 
+# Gemini: Resolve CMP0042 (macOS-only).
+if (APPLE)
+  set(CMAKE_MACOSX_RPATH 1)
+endif()
+
 if(COMMAND cmake_policy)
       cmake_policy(SET CMP0003 NEW)
 endif(COMMAND cmake_policy)
 
 project (pkcs11 C)
 
+# Gemini: syscall-reporter.c and syscall-names.h apply only to Linux. Build only in debug mode.
 set(PKCS11_PROXY_SRCS gck-rpc-module.c gck-rpc-message.c gck-rpc-util.c egg-buffer.c gck-rpc-tls-psk.c)
-set(PKCS11_DAEMON_SRCS egg-buffer.c gck-rpc-daemon-standalone.c gck-rpc-dispatch.c gck-rpc-message.c gck-rpc-util.c syscall-reporter.c syscall-names.h gck-rpc-tls-psk.c)
+set(PKCS11_DAEMON_SRCS egg-buffer.c gck-rpc-daemon-standalone.c gck-rpc-dispatch.c gck-rpc-message.c gck-rpc-util.c gck-rpc-tls-psk.c)
+macro (CHECK_IF_DEBUG)
+  if (CMAKE_BUILD_TYPE MATCHES Debug)
+    if (NOT APPLE)
+      set(PKCS11_DAEMON_SRCS ${PKCS11_DAEMON_SRCS} syscall-reporter.c syscall-names.h)
+    endif()
+  endif()
+endmacro()
 
 add_definitions(-Wall)
 add_library(pkcs11-proxy SHARED ${PKCS11_PROXY_SRCS})
@@ -21,6 +34,15 @@ endif()
 
 add_executable (pkcs11-daemon ${GUI_TYPE} ${PKCS11_DAEMON_SRCS})
 
+# Gemini: Linking OpenSSL on macOS is a bit fragile. We can't link Apple's version of
+# OpenSSL (https://developer.apple.com/forums/thread/124782?answerId=390243022#390243022).
+# Instead, we need to install the latest version via brew, confirm the package is found,
+# and then add an include directory (here) and link directory (below).
+if (APPLE)
+  find_package(OpenSSL REQUIRED)
+  include_directories (/usr/local/opt/openssl/include)
+endif()
+
 set_target_properties(pkcs11-proxy PROPERTIES VERSION 0.1 SOVERSION 0)
 
 if (WIN32)
@@ -33,13 +55,22 @@ if (WIN32)
   target_link_libraries (pkcs11-proxy ws2_32)
 endif (WIN32)
 
-target_link_libraries (pkcs11-proxy ssl crypto pthread)
-target_link_libraries (pkcs11-daemon dl ssl crypto pthread seccomp)
+# Gemini: Link directory added.
+if (APPLE)
+  target_link_libraries (pkcs11-proxy -L/usr/local/opt/openssl/lib ssl crypto pthread)
+  target_link_libraries (pkcs11-daemon dl -L/usr/local/opt/openssl/lib ssl crypto pthread)
+else()
+  target_link_libraries (pkcs11-proxy ssl crypto pthread)
+  target_link_libraries (pkcs11-daemon dl ssl crypto pthread seccomp)
+endif()
 
 install_targets (/lib pkcs11-proxy)
 install_targets (/bin pkcs11-daemon)
 
-add_custom_command(
-   OUTPUT syscall-names.h 
-   COMMAND ${CMAKE_SOURCE_DIR}/mksyscalls.sh
-   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+# Gemini: Don't perform command on macOS.
+if (NOT APPLE)
+  add_custom_command(
+     OUTPUT syscall-names.h
+     COMMAND ${CMAKE_SOURCE_DIR}/mksyscalls.sh
+     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+endif()

--- a/gck-rpc-dispatch.c
+++ b/gck-rpc-dispatch.c
@@ -63,6 +63,11 @@
 #endif /* SECCOMP */
 #include <sys/mman.h>
 
+// Gemini: Add the __APPLE__ directive.
+#if __APPLE__
+#define MSG_NOSIGNAL 0x2000 /* don't raise SIGPIPE */
+#endif
+
 /* Where we dispatch the calls to */
 static CK_FUNCTION_LIST_PTR pkcs11_module = NULL;
 


### PR DESCRIPTION
- Allow compilation on macOS while not interfering with *NIX compilation.
- Add minor CMake cleanup to avoid some compiler warnings in Linux.